### PR TITLE
Deafault to ByteArraySerializer when schema.registry.url is not set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build artifacts
         uses: gradle/gradle-build-action@v2.4.0
         with:
-          arguments: assembleDist
+          arguments: distTar
       - name: Upload artifacts
         uses: ncipollo/release-action@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (docs/ci) [PR 32](https://github.com/provenance-io/provenance-abci-listener/pull/31) Update deploy doc and scripts and mark pre-releases
 * (docs) [PR 33](https://github.com/provenance-io/provenance-abci-listener/pull/33) Fix typos in deploy steps
+* [PR 38](https://github.com/provenance-io/provenance-abci-listener/pull/38) Default to ByteArraySerializer when `schema.registry.url` property is not set
 
 ---
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ group = "io.provenance"
 version = System.getenv("VERSION") ?: "0-SNAPSHOT"
 
 application {
-    mainClass.set("io.provenance.abci.listener.ABCIListenerServerKt")
+    mainClass.set("io.provenance.abci.listener.AbciListenerServerKt")
 }
 
 repositories {
@@ -84,7 +84,7 @@ tasks.withType<KotlinCompile> {
     kotlinOptions {
         freeCompilerArgs = listOf(
             "-Xjsr305=strict",
-            "-Xopt-in=kotlin.RequiresOptIn"
+            "-opt-in=kotlin.RequiresOptIn"
         )
         jvmTarget = "11"
         languageVersion = "1.7"
@@ -92,8 +92,10 @@ tasks.withType<KotlinCompile> {
     }
 }
 
-tasks.assembleDist {
-    finalizedBy("checksumDist") // checksums are generated after assembleDist runs
+tasks.distTar {
+    compression = Compression.GZIP
+    archiveExtension.set("tar.gz")
+    finalizedBy("checksumDist")
 }
 
 tasks.register<Checksum>("checksumDist") {
@@ -103,7 +105,7 @@ tasks.register<Checksum>("checksumDist") {
     checksumAlgorithm.set(Checksum.Algorithm.MD5)
     appendFileNameToChecksum.set(true)
 
-    dependsOn(tasks.assembleDist)
+    dependsOn(tasks.distTar)
 }
 
 tasks.withType<Test> {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,7 +2,7 @@
 
 #
 # Download plugin distribution and extract the plugin.
-# In addition, validate the md5 checksum of the zip file.
+# In addition, validate the md5 checksum of the file.
 #
 
 usage() {
@@ -24,7 +24,7 @@ TAG=$1
 PLUGINS_HOME="$PIO_HOME/plugins"
 PLUGIN_NAME=provenance-abci-listener
 PLUGIN_DIR="$PLUGINS_HOME/$PLUGIN_NAME-$TAG"
-RELEASE_URL="https://github.com/provenance-io/provenance-abci-listener/releases/download/$TAG/provenance-abci-listener-$TAG.zip"
+RELEASE_URL="https://github.com/provenance-io/provenance-abci-listener/releases/download/$TAG/provenance-abci-listener-$TAG.tar.gz"
 
 [[ -z "$TAG" ]] && usage;
 
@@ -32,13 +32,14 @@ echo "Release: $TAG"
 
 # download release distribution
 echo "Downloading release..."
-curl -s --create-dirs -o "$PLUGIN_DIR.zip" -L "$RELEASE_URL"
+curl -s --create-dirs -o "$PLUGIN_DIR.tar.gz" -L "$RELEASE_URL"
 
 # validate md5 checksum
 echo "Validating release (md5)..."
-curl -s --create-dirs -o "$PLUGIN_DIR.zip.md5" -L "$RELEASE_URL.md5"
+curl -s --create-dirs -o "$PLUGIN_DIR.tar.gz.md5" -L "$RELEASE_URL.md5"
 cd "$PLUGINS_HOME" || exit 1
-md5sum -c "$PLUGIN_DIR.zip.md5" || exit 1
+md5sum -c "$PLUGIN_DIR.tar.gz.md5" || exit 1
 
 echo "Extracting release..."
-unzip -qq "$PLUGIN_DIR.zip" -d "$PLUGINS_HOME"
+tar -zxf "$PLUGIN_DIR.tar.gz" -C "$PLUGINS_HOME"
+rm "$PLUGIN_DIR.tar.gz"

--- a/src/main/kotlin/io/provenance/abci/listener/AbciListenerServer.kt
+++ b/src/main/kotlin/io/provenance/abci/listener/AbciListenerServer.kt
@@ -8,21 +8,20 @@ import io.grpc.health.v1.HealthCheckResponse.ServingStatus
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder
 import io.grpc.protobuf.services.HealthStatusManager
 import io.grpc.protobuf.services.ProtoReflectionService
-import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.Producer
 import java.net.InetSocketAddress
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 /**
- * The [ABCIListenerServer] starts the gRPC server for the [ABCIListenerService].
- * In addition to the [ABCIListenerService], a health service (managed by [HealthStatusManager])
+ * The [ABCIListenerServer] starts the gRPC server for the [AbciListenerService].
+ * In addition to the [AbciListenerService], a health service (managed by [HealthStatusManager])
  * and a [ProtoReflectionService] are also added.
  *
  * The server is also responsible for initializing and closing the Kafka [Producer]
- * used by the [ABCIListenerService].
+ * used by the [AbciListenerService].
  */
-class ABCIListenerServer {
+class AbciListenerServer {
     private val config: Config = ConfigFactory.load()
     private val inet = InetSocketAddress(
         config.getString("grpc.server.addr"),
@@ -30,20 +29,20 @@ class ABCIListenerServer {
     )
 
     // Kafka producer
-    private var topicConfig: Config = config.getConfig("kafka.producer.listen-topics")
-    private var kafkaConfig: Config = config.getConfig("kafka.producer.kafka-clients")
-    private val producer: Producer<String, Message> = KafkaProducer(kafkaConfig.toProperties())
+    private var producerConfig: Config = config.getConfig("kafka.producer")
+    private var topicConfig: Config = producerConfig.getConfig("listen-topics")
+    private val producer = ProducerSettings<String, Message>(producerConfig).createKafkaProducer()
 
     private val health: HealthStatusManager = HealthStatusManager()
-    val server: Server = NettyServerBuilder
+    private val server: Server = NettyServerBuilder
         .forAddress(inet)
         .directExecutor()
         .addService(health.healthService)
         .addService(ProtoReflectionService.newInstance())
-        .addService(ABCIListenerService(topicConfig, producer))
+        .addService(AbciListenerService(topicConfig, producer))
         .build()
 
-    /** Start the [ABCIListenerService] gRPC server. */
+    /** Start the [AbciListenerService] gRPC server. */
     fun start() {
         server.start()
 
@@ -57,13 +56,13 @@ class ABCIListenerServer {
         Runtime.getRuntime().addShutdownHook(
             Thread {
                 println("*** shutting down gRPC server since JVM is shutting down")
-                this@ABCIListenerServer.stop()
+                this@AbciListenerServer.stop()
                 println("*** server shut down")
             }
         )
     }
 
-    /** Stop the [ABCIListenerService] gRPC server. */
+    /** Stop the [AbciListenerService] gRPC server. */
     private fun stop() {
         // shutdown producer
         producer.close(Duration.ofMillis(3000))
@@ -98,7 +97,7 @@ class ABCIListenerServer {
 }
 
 fun main() {
-    val server = ABCIListenerServer()
+    val server = AbciListenerServer()
     server.start()
     server.blockUntilShutdown()
 }

--- a/src/main/kotlin/io/provenance/abci/listener/AbciListenerService.kt
+++ b/src/main/kotlin/io/provenance/abci/listener/AbciListenerService.kt
@@ -15,7 +15,7 @@ import org.apache.kafka.clients.producer.Producer
 import org.apache.kafka.clients.producer.ProducerRecord
 
 /**
- * Producer topic names for the [ABCIListenerService]
+ * Producer topic names for the [AbciListenerService]
  */
 enum class ListenTopic(val topic: String) {
     BEGIN_BLOCK("listen-begin-block"),
@@ -31,7 +31,7 @@ enum class ListenTopic(val topic: String) {
  * @property producer the Kafka Protobuf [Producer].
  * @constructor Creates a gRPC ABCI listener service.
  */
-class ABCIListenerService(
+class AbciListenerService(
     private val topicConfig: Config,
     private val producer: Producer<String, Message>
 ) : ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineImplBase() {

--- a/src/main/kotlin/io/provenance/abci/listener/Extensions.kt
+++ b/src/main/kotlin/io/provenance/abci/listener/Extensions.kt
@@ -28,7 +28,7 @@ fun Config.toProperties(): Properties {
 /**
  * Add a [dispatch] method to the Kafka [Producer] to produce messages
  * in a non-blocking manner and `await` for acknowledgement from broker
- * before responding on gRPC endpoints in [ABCIListenerService].
+ * before responding on gRPC endpoints in [AbciListenerService].
  *
  * Resumes with a [StatusException] when an exception is encountered.
  */

--- a/src/main/kotlin/io/provenance/abci/listener/ProducerSettings.kt
+++ b/src/main/kotlin/io/provenance/abci/listener/ProducerSettings.kt
@@ -1,0 +1,31 @@
+package io.provenance.abci.listener
+
+import com.typesafe.config.Config
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.Producer
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.Serializer
+
+class ProducerSettings<K, V>(
+    private val config: Config,
+    private val keySerializer: Serializer<K>? = null,
+    private val valueSerializer: Serializer<V>? = null,
+) {
+
+    fun createKafkaProducer(): Producer<K, V> {
+        val properties = config.getConfig("kafka-clients").toProperties()
+        require(
+            keySerializer != null ||
+                    properties.getProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG).isNotEmpty()) {
+            "Key serializer should be defined or declared in configuration"
+        }
+
+        require(
+            valueSerializer != null ||
+                    properties.getProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG).isNotEmpty()) {
+            "Value serializer should be defined or declared in configuration"
+        }
+
+        return KafkaProducer(properties)
+    }
+}

--- a/src/main/kotlin/io/provenance/abci/listener/ProducerSettings.kt
+++ b/src/main/kotlin/io/provenance/abci/listener/ProducerSettings.kt
@@ -9,20 +9,22 @@ import org.apache.kafka.common.serialization.Serializer
 class ProducerSettings<K, V>(
     private val config: Config,
     private val keySerializer: Serializer<K>? = null,
-    private val valueSerializer: Serializer<V>? = null,
+    private val valueSerializer: Serializer<V>? = null
 ) {
 
     fun createKafkaProducer(): Producer<K, V> {
         val properties = config.getConfig("kafka-clients").toProperties()
         require(
             keySerializer != null ||
-                    properties.getProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG).isNotEmpty()) {
+                properties.getProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG).isNotEmpty()
+        ) {
             "Key serializer should be defined or declared in configuration"
         }
 
         require(
             valueSerializer != null ||
-                    properties.getProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG).isNotEmpty()) {
+                properties.getProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG).isNotEmpty()
+        ) {
             "Value serializer should be defined or declared in configuration"
         }
 

--- a/src/main/kotlin/io/provenance/abci/listener/ProtobufSerializer.kt
+++ b/src/main/kotlin/io/provenance/abci/listener/ProtobufSerializer.kt
@@ -1,0 +1,78 @@
+package io.provenance.abci.listener
+
+import com.google.protobuf.Message
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer
+import java.io.ByteArrayOutputStream
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import org.apache.kafka.common.serialization.Serializer
+
+/**
+ * ProtobufSerializer is a custom Protobuf serializer for Kafka
+ * that chooses a serialization path based on whether the application
+ * is configured to use the Confluent Schema Registry or not.
+ *
+ * When the application is configured to use the Confluent Schema Registry
+ * the [KafkaProtobufSerializer] will be used. Otherwise, the [ByteArraySerializer] will be used.
+ *
+ * In order to enable the application to use the Confluent Schema Registry,
+ * you MUST set the following properties:
+ *
+ *  `schema.registry.url={{ SR_URL }}`
+ *  `value.serializer=io.provenance.abci.listener.ProtobufSerializer`.
+ *
+ *  Example configuration:
+ *
+ *      ```
+ *      # application.conf
+ *
+ *      # application configuration properties
+ *      ...
+ *
+ *      kafka.producer {
+ *          ...
+ *          # Properties defined by org.apache.kafka.clients.producer.ProducerConfig.
+ *          # can be defined in this configuration section.
+ *          kafka-clients {
+ *              bootstrap.servers = "localhost:9092"
+ *              // other producer properties
+ *              ...
+ *              key.serializer = org.apache.kafka.common.serialization.StringSerializer
+ *              value.serializer = io.provenance.abci.listener.ProtobufSerializer
+ *              schema.registry.url = "http://127.0.0.1:8081"
+ *          }
+ *      }
+ *      ```
+ * For additional producer properties see [org.apache.kafka.clients.producer.ProducerConfig]
+ *
+ */
+class ProtobufSerializer<T : Message> : Serializer<T> {
+    private lateinit var serializer: Serializer<T>
+
+    override fun configure(configs: MutableMap<String, *>?, isKey: Boolean) {
+        val useSchemaRegistry = configs!!.containsKey(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG)
+        if (useSchemaRegistry) {
+            val serializer = KafkaProtobufSerializer<T>()
+            serializer.configure(configs, isKey)
+            this.serializer = serializer
+        } else {
+            val serializer = ByteArraySerializer()
+            @Suppress("UNCHECKED_CAST")
+            this.serializer = serializer as Serializer<T>
+        }
+    }
+
+    override fun serialize(topic: String?, data: T): ByteArray {
+        var bytes: ByteArray = byteArrayOf()
+        when (serializer) {
+            is KafkaProtobufSerializer -> bytes = serializer.serialize(topic, data)
+            is ByteArraySerializer -> {
+                val out = ByteArrayOutputStream()
+                data.writeTo(out)
+                bytes = out.toByteArray()
+                out.close()
+            }
+        }
+        return bytes
+    }
+}

--- a/src/main/kotlin/io/provenance/abci/listener/ProtobufSerializer.kt
+++ b/src/main/kotlin/io/provenance/abci/listener/ProtobufSerializer.kt
@@ -3,9 +3,9 @@ package io.provenance.abci.listener
 import com.google.protobuf.Message
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer
-import java.io.ByteArrayOutputStream
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.apache.kafka.common.serialization.Serializer
+import java.io.ByteArrayOutputStream
 
 /**
  * ProtobufSerializer is a custom Protobuf serializer for Kafka

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -6,9 +6,9 @@ grpc.server {
 
 # Kafka producer config
 kafka.producer {
-  # Assign a topic name and an optional prefix where events will be written.
+  # Assign a topic name and optional prefix where events will be written.
   listen-topics {
-    prefix = "local-"
+    prefix = "bytetest-"
     listen-begin-block = ${?kafka.producer.listen-topics.prefix}"listen-begin-block"
     listen-end-block = ${?kafka.producer.listen-topics.prefix}"listen-end-block"
     listen-deliver-tx = ${?kafka.producer.listen-topics.prefix}"listen-deliver-tx"
@@ -25,7 +25,7 @@ kafka.producer {
     linger.ms = 50
     max.request.size = 204857600
     key.serializer = org.apache.kafka.common.serialization.StringSerializer
-    value.serializer = io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer
-    schema.registry.url = "http://127.0.0.1:8081"
+    value.serializer = io.provenance.abci.listener.ProtobufSerializer
+    //    schema.registry.url = "http://127.0.0.1:8081"
   }
 }

--- a/src/test/kotlin/io/provenance/abci/listener/AbciListenerServerWithSchemaRegistryTests.kt
+++ b/src/test/kotlin/io/provenance/abci/listener/AbciListenerServerWithSchemaRegistryTests.kt
@@ -4,7 +4,6 @@ import com.google.protobuf.ByteString
 import com.google.protobuf.Message
 import com.google.protobuf.Timestamp
 import cosmos.base.store.v1beta1.Listening.StoreKVPair
-import cosmos.streaming.abci.v1.ABCIListenerServiceGrpcKt
 import cosmos.streaming.abci.v1.Grpc.ListenBeginBlockRequest
 import cosmos.streaming.abci.v1.Grpc.ListenBeginBlockResponse
 import cosmos.streaming.abci.v1.Grpc.ListenCommitRequest
@@ -13,10 +12,11 @@ import cosmos.streaming.abci.v1.Grpc.ListenDeliverTxRequest
 import cosmos.streaming.abci.v1.Grpc.ListenDeliverTxResponse
 import cosmos.streaming.abci.v1.Grpc.ListenEndBlockRequest
 import cosmos.streaming.abci.v1.Grpc.ListenEndBlockResponse
-import io.grpc.inprocess.InProcessChannelBuilder
 import io.grpc.inprocess.InProcessServerBuilder
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import tendermint.abci.Types
@@ -28,9 +28,6 @@ import tendermint.abci.Types.ResponseCommit
 import tendermint.abci.Types.ResponseDeliverTx
 import tendermint.abci.Types.ResponseEndBlock
 import java.time.Instant
-import org.apache.kafka.clients.producer.Producer
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AbciListenerServerWithSchemaRegistryTests : BaseTests() {
@@ -40,7 +37,7 @@ class AbciListenerServerWithSchemaRegistryTests : BaseTests() {
         schemaRegistry = testContainerFactory.createSchemaRegistry(kafka)
         schemaRegistry.start()
         producer = TestProtoProducer<String, Message>(config, schemaRegistry.baseUrl)
-                .createProducer(kafka.bootstrapServers)
+            .createProducer(kafka.bootstrapServers)
     }
 
     @AfterAll

--- a/src/test/kotlin/io/provenance/abci/listener/AbciListenerServerWithSchemaRegistryTests.kt
+++ b/src/test/kotlin/io/provenance/abci/listener/AbciListenerServerWithSchemaRegistryTests.kt
@@ -4,6 +4,7 @@ import com.google.protobuf.ByteString
 import com.google.protobuf.Message
 import com.google.protobuf.Timestamp
 import cosmos.base.store.v1beta1.Listening.StoreKVPair
+import cosmos.streaming.abci.v1.ABCIListenerServiceGrpcKt
 import cosmos.streaming.abci.v1.Grpc.ListenBeginBlockRequest
 import cosmos.streaming.abci.v1.Grpc.ListenBeginBlockResponse
 import cosmos.streaming.abci.v1.Grpc.ListenCommitRequest
@@ -12,6 +13,7 @@ import cosmos.streaming.abci.v1.Grpc.ListenDeliverTxRequest
 import cosmos.streaming.abci.v1.Grpc.ListenDeliverTxResponse
 import cosmos.streaming.abci.v1.Grpc.ListenEndBlockRequest
 import cosmos.streaming.abci.v1.Grpc.ListenEndBlockResponse
+import io.grpc.inprocess.InProcessChannelBuilder
 import io.grpc.inprocess.InProcessServerBuilder
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -31,6 +33,31 @@ import java.time.Instant
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AbciListenerServerWithSchemaRegistryTests : BaseTests() {
+
+    private val listenBeginBlockStub =
+        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
+            grpcCleanupRule.register(
+                InProcessChannelBuilder.forName("listenBeginBlock_with_schemaRegistry").directExecutor().build()
+            )
+        )
+    private val listenEndBlockStub =
+        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
+            grpcCleanupRule.register(
+                InProcessChannelBuilder.forName("listenEndBlock_with_schemaRegistry").directExecutor().build()
+            )
+        )
+    private val listenDeliverTxStub =
+        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
+            grpcCleanupRule.register(
+                InProcessChannelBuilder.forName("listenDeliverTx_with_schemaRegistry").directExecutor().build()
+            )
+        )
+    private val listenCommitStub =
+        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
+            grpcCleanupRule.register(
+                InProcessChannelBuilder.forName("listenCommit_with_schemaRegistry").directExecutor().build()
+            )
+        )
 
     @BeforeAll
     internal fun setUpAll() {
@@ -52,7 +79,7 @@ class AbciListenerServerWithSchemaRegistryTests : BaseTests() {
         val time = Instant.now()
 
         grpcCleanupRule.register(
-            InProcessServerBuilder.forName("listenBeginBlock").directExecutor()
+            InProcessServerBuilder.forName("listenBeginBlock_with_schemaRegistry").directExecutor()
                 .addService(AbciListenerService(topicConfig, producer))
                 .build()
                 .start()
@@ -114,7 +141,7 @@ class AbciListenerServerWithSchemaRegistryTests : BaseTests() {
     @Test
     fun listenEndBlock(): Unit = runBlocking {
         grpcCleanupRule.register(
-            InProcessServerBuilder.forName("listenEndBlock").directExecutor()
+            InProcessServerBuilder.forName("listenEndBlock_with_schemaRegistry").directExecutor()
                 .addService(AbciListenerService(topicConfig, producer))
                 .build()
                 .start()
@@ -144,7 +171,7 @@ class AbciListenerServerWithSchemaRegistryTests : BaseTests() {
     @Test
     fun listenDeliverTx(): Unit = runBlocking {
         grpcCleanupRule.register(
-            InProcessServerBuilder.forName("listenDeliverTx").directExecutor()
+            InProcessServerBuilder.forName("listenDeliverTx_with_schemaRegistry").directExecutor()
                 .addService(AbciListenerService(topicConfig, producer))
                 .build()
                 .start()
@@ -176,7 +203,7 @@ class AbciListenerServerWithSchemaRegistryTests : BaseTests() {
     @Test
     fun listenCommit(): Unit = runBlocking {
         grpcCleanupRule.register(
-            InProcessServerBuilder.forName("listenCommit").directExecutor()
+            InProcessServerBuilder.forName("listenCommit_with_schemaRegistry").directExecutor()
                 .addService(AbciListenerService(topicConfig, producer))
                 .build()
                 .start()

--- a/src/test/kotlin/io/provenance/abci/listener/AbciListenerServerWithSchemaRegistryTests.kt
+++ b/src/test/kotlin/io/provenance/abci/listener/AbciListenerServerWithSchemaRegistryTests.kt
@@ -1,0 +1,226 @@
+package io.provenance.abci.listener
+
+import com.google.protobuf.ByteString
+import com.google.protobuf.Message
+import com.google.protobuf.Timestamp
+import cosmos.base.store.v1beta1.Listening.StoreKVPair
+import cosmos.streaming.abci.v1.ABCIListenerServiceGrpcKt
+import cosmos.streaming.abci.v1.Grpc.ListenBeginBlockRequest
+import cosmos.streaming.abci.v1.Grpc.ListenBeginBlockResponse
+import cosmos.streaming.abci.v1.Grpc.ListenCommitRequest
+import cosmos.streaming.abci.v1.Grpc.ListenCommitResponse
+import cosmos.streaming.abci.v1.Grpc.ListenDeliverTxRequest
+import cosmos.streaming.abci.v1.Grpc.ListenDeliverTxResponse
+import cosmos.streaming.abci.v1.Grpc.ListenEndBlockRequest
+import cosmos.streaming.abci.v1.Grpc.ListenEndBlockResponse
+import io.grpc.inprocess.InProcessChannelBuilder
+import io.grpc.inprocess.InProcessServerBuilder
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import tendermint.abci.Types
+import tendermint.abci.Types.RequestBeginBlock
+import tendermint.abci.Types.RequestDeliverTx
+import tendermint.abci.Types.RequestEndBlock
+import tendermint.abci.Types.ResponseBeginBlock
+import tendermint.abci.Types.ResponseCommit
+import tendermint.abci.Types.ResponseDeliverTx
+import tendermint.abci.Types.ResponseEndBlock
+import java.time.Instant
+import org.apache.kafka.clients.producer.Producer
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AbciListenerServerWithSchemaRegistryTests : BaseTests() {
+
+    @BeforeAll
+    internal fun setUpAll() {
+        schemaRegistry = testContainerFactory.createSchemaRegistry(kafka)
+        schemaRegistry.start()
+        producer = TestProtoProducer<String, Message>(config, schemaRegistry.baseUrl)
+                .createProducer(kafka.bootstrapServers)
+    }
+
+    @AfterAll
+    internal fun tearDownAll() {
+        producer.close()
+        schemaRegistry.stop()
+        kafka.stop()
+    }
+
+    @Test
+    fun listenBeginBlock(): Unit = runBlocking {
+        val time = Instant.now()
+
+        grpcCleanupRule.register(
+            InProcessServerBuilder.forName("listenBeginBlock").directExecutor()
+                .addService(AbciListenerService(topicConfig, producer))
+                .build()
+                .start()
+        )
+
+        val reply: ListenBeginBlockResponse = listenBeginBlockStub.listenBeginBlock(
+            ListenBeginBlockRequest.newBuilder()
+                .setReq(
+                    RequestBeginBlock.newBuilder()
+                        .setHeader(
+                            tendermint.types.Types.Header.newBuilder()
+                                .setHeight(1)
+                                .setTime(
+                                    Timestamp.newBuilder()
+                                        .setSeconds(time.epochSecond)
+                                        .setNanos(time.nano)
+                                        .build()
+                                )
+                                .build()
+                        )
+                        .addAllByzantineValidators(emptyList())
+                        .setHash(ByteString.copyFrom(byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8, 9)))
+                        .setLastCommitInfo(
+                            Types.LastCommitInfo.newBuilder()
+                                .setRound(1)
+                                .addAllVotes(emptyList())
+                                .build()
+                        )
+                        .build()
+                )
+                .setRes(
+                    ResponseBeginBlock.newBuilder()
+                        .addAllEvents(
+                            listOf(
+                                Types.Event.newBuilder()
+                                    .setType("testEventType1")
+                                    .build()
+                            )
+                        )
+                        .build()
+                )
+                .build()
+        )
+        assertThat(reply.javaClass).isEqualTo(ListenBeginBlockResponse::class.java)
+
+        val consumer = TestProtoConsumer<String, ListenBeginBlockRequest>(
+            config = config,
+            bootstrapServers = kafka.bootstrapServers,
+            schemaRegistryUrl = schemaRegistry.baseUrl,
+            topic = topicConfig.getString(ListenTopic.BEGIN_BLOCK.topic),
+            valueClass = ListenBeginBlockRequest::class.java
+        )
+        consumer.consumeAndClose()
+        assertThat(consumer.messages.size).isEqualTo(1)
+        assertThat(consumer.messages[0].value().req.header.height).isEqualTo(1)
+        assertThat(consumer.messages[0].value().res.eventsList[0].type).isEqualTo("testEventType1")
+    }
+
+    @Test
+    fun listenEndBlock(): Unit = runBlocking {
+        grpcCleanupRule.register(
+            InProcessServerBuilder.forName("listenEndBlock").directExecutor()
+                .addService(AbciListenerService(topicConfig, producer))
+                .build()
+                .start()
+        )
+
+        val reply: ListenEndBlockResponse = listenEndBlockStub.listenEndBlock(
+            ListenEndBlockRequest.newBuilder()
+                .setReq(RequestEndBlock.newBuilder().setHeight(1).build())
+                .setRes(ResponseEndBlock.newBuilder().build())
+                .build()
+        )
+        assertThat(reply.javaClass).isEqualTo(ListenEndBlockResponse::class.java)
+
+        val consumer = TestProtoConsumer<String, ListenEndBlockRequest>(
+            config = config,
+            bootstrapServers = kafka.bootstrapServers,
+            schemaRegistryUrl = schemaRegistry.baseUrl,
+            topic = topicConfig.getString(ListenTopic.END_BLOCK.topic),
+            valueClass = ListenEndBlockRequest::class.java
+        )
+        consumer.consumeAndClose()
+        assertThat(consumer.messages.size).isEqualTo(1)
+        assertThat(consumer.messages[0].value().req.height).isEqualTo(1)
+        assertThat(consumer.messages[0].value().res.eventsList.size).isEqualTo(0)
+    }
+
+    @Test
+    fun listenDeliverTx(): Unit = runBlocking {
+        grpcCleanupRule.register(
+            InProcessServerBuilder.forName("listenDeliverTx").directExecutor()
+                .addService(AbciListenerService(topicConfig, producer))
+                .build()
+                .start()
+        )
+
+        val reply: ListenDeliverTxResponse = listenDeliverTxStub.listenDeliverTx(
+            ListenDeliverTxRequest.newBuilder()
+                .setBlockHeight(1)
+                .setReq(RequestDeliverTx.newBuilder().setTx(ByteString.copyFrom("testTx1".toByteArray())).build())
+                .setRes(ResponseDeliverTx.newBuilder().setCode(1).build())
+                .build()
+        )
+        assertThat(reply.javaClass).isEqualTo(ListenDeliverTxResponse::class.java)
+
+        val consumer = TestProtoConsumer<String, ListenDeliverTxRequest>(
+            config = config,
+            bootstrapServers = kafka.bootstrapServers,
+            schemaRegistryUrl = schemaRegistry.baseUrl,
+            topic = topicConfig.getString(ListenTopic.DELIVER_TX.topic),
+            valueClass = ListenDeliverTxRequest::class.java
+        )
+        consumer.consumeAndClose()
+        assertThat(consumer.messages.size).isEqualTo(1)
+        assertThat(consumer.messages[0].value().blockHeight).isEqualTo(1)
+        assertThat(consumer.messages[0].value().req.tx.toStringUtf8()).isEqualTo("testTx1")
+        assertThat(consumer.messages[0].value().res.code).isEqualTo(1)
+    }
+
+    @Test
+    fun listenCommit(): Unit = runBlocking {
+        grpcCleanupRule.register(
+            InProcessServerBuilder.forName("listenCommit").directExecutor()
+                .addService(AbciListenerService(topicConfig, producer))
+                .build()
+                .start()
+        )
+
+        val changeSet = mutableListOf<StoreKVPair>()
+        for (i in 1..2000) {
+            changeSet.add(
+                StoreKVPair.newBuilder()
+                    .setStoreKey("mockStore1")
+                    .setKey(ByteString.copyFrom("key$i".toByteArray()))
+                    .setValue(ByteString.copyFrom("val$i".toByteArray()))
+                    .setDelete(false)
+                    .build()
+            )
+        }
+
+        val reply: ListenCommitResponse = listenCommitStub.listenCommit(
+            ListenCommitRequest.newBuilder()
+                .setBlockHeight(1)
+                .setRes(
+                    ResponseCommit.newBuilder()
+                        .setData(ByteString.copyFrom("data123".toByteArray()))
+                        .build()
+                )
+                .addAllChangeSet(changeSet)
+                .build()
+        )
+        assertThat(reply.javaClass).isEqualTo(ListenCommitResponse::class.java)
+
+        val consumer = TestProtoConsumer<String, ListenCommitRequest>(
+            config = config,
+            bootstrapServers = kafka.bootstrapServers,
+            schemaRegistryUrl = schemaRegistry.baseUrl,
+            topic = topicConfig.getString(ListenTopic.COMMIT.topic),
+            valueClass = ListenCommitRequest::class.java
+        )
+        consumer.consumeAndClose()
+        assertThat(consumer.messages.size).isEqualTo(1)
+        assertThat(consumer.messages[0].value().blockHeight).isEqualTo(1)
+        assertThat(consumer.messages[0].value().res.data.toStringUtf8()).isEqualTo("data123")
+        assertThat(consumer.messages[0].value().changeSetList[0].storeKey).isEqualTo("mockStore1")
+    }
+}

--- a/src/test/kotlin/io/provenance/abci/listener/AbciListenerServerWithoutSchemaRegistryTests.kt
+++ b/src/test/kotlin/io/provenance/abci/listener/AbciListenerServerWithoutSchemaRegistryTests.kt
@@ -4,6 +4,7 @@ import com.google.protobuf.ByteString
 import com.google.protobuf.Message
 import com.google.protobuf.Timestamp
 import cosmos.base.store.v1beta1.Listening.StoreKVPair
+import cosmos.streaming.abci.v1.ABCIListenerServiceGrpcKt
 import cosmos.streaming.abci.v1.Grpc.ListenBeginBlockRequest
 import cosmos.streaming.abci.v1.Grpc.ListenBeginBlockResponse
 import cosmos.streaming.abci.v1.Grpc.ListenCommitRequest
@@ -12,6 +13,7 @@ import cosmos.streaming.abci.v1.Grpc.ListenDeliverTxRequest
 import cosmos.streaming.abci.v1.Grpc.ListenDeliverTxResponse
 import cosmos.streaming.abci.v1.Grpc.ListenEndBlockRequest
 import cosmos.streaming.abci.v1.Grpc.ListenEndBlockResponse
+import io.grpc.inprocess.InProcessChannelBuilder
 import io.grpc.inprocess.InProcessServerBuilder
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -32,6 +34,31 @@ import java.time.Instant
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AbciListenerServerWithoutSchemaRegistryTests : BaseTests() {
+
+    private val listenBeginBlockStub =
+        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
+            grpcCleanupRule.register(
+                InProcessChannelBuilder.forName("listenBeginBlock").directExecutor().build()
+            )
+        )
+    private val listenEndBlockStub =
+        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
+            grpcCleanupRule.register(
+                InProcessChannelBuilder.forName("listenEndBlock").directExecutor().build()
+            )
+        )
+    private val listenDeliverTxStub =
+        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
+            grpcCleanupRule.register(
+                InProcessChannelBuilder.forName("listenDeliverTx").directExecutor().build()
+            )
+        )
+    private val listenCommitStub =
+        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
+            grpcCleanupRule.register(
+                InProcessChannelBuilder.forName("listenCommit").directExecutor().build()
+            )
+        )
 
     @BeforeAll
     internal fun setUpAll() {

--- a/src/test/kotlin/io/provenance/abci/listener/AbciListenerServerWithoutSchemaRegistryTests.kt
+++ b/src/test/kotlin/io/provenance/abci/listener/AbciListenerServerWithoutSchemaRegistryTests.kt
@@ -3,10 +3,7 @@ package io.provenance.abci.listener
 import com.google.protobuf.ByteString
 import com.google.protobuf.Message
 import com.google.protobuf.Timestamp
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
 import cosmos.base.store.v1beta1.Listening.StoreKVPair
-import cosmos.streaming.abci.v1.ABCIListenerServiceGrpcKt
 import cosmos.streaming.abci.v1.Grpc.ListenBeginBlockRequest
 import cosmos.streaming.abci.v1.Grpc.ListenBeginBlockResponse
 import cosmos.streaming.abci.v1.Grpc.ListenCommitRequest
@@ -15,20 +12,11 @@ import cosmos.streaming.abci.v1.Grpc.ListenDeliverTxRequest
 import cosmos.streaming.abci.v1.Grpc.ListenDeliverTxResponse
 import cosmos.streaming.abci.v1.Grpc.ListenEndBlockRequest
 import cosmos.streaming.abci.v1.Grpc.ListenEndBlockResponse
-import io.grpc.inprocess.InProcessChannelBuilder
 import io.grpc.inprocess.InProcessServerBuilder
-import io.grpc.testing.GrpcCleanupRule
 import kotlinx.coroutines.runBlocking
-import net.christophschubert.cp.testcontainers.CPTestContainerFactory
-import net.christophschubert.cp.testcontainers.SchemaRegistryContainer
-import org.apache.kafka.clients.producer.Producer
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Rule
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.testcontainers.containers.KafkaContainer
 import tendermint.abci.Types
 import tendermint.abci.Types.RequestBeginBlock
 import tendermint.abci.Types.RequestDeliverTx
@@ -38,55 +26,23 @@ import tendermint.abci.Types.ResponseCommit
 import tendermint.abci.Types.ResponseDeliverTx
 import tendermint.abci.Types.ResponseEndBlock
 import java.time.Instant
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.assertDoesNotThrow
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class ABCIListenerServerTest {
-
-    private val testContainerFactory: CPTestContainerFactory = CPTestContainerFactory()
-    private val kafka: KafkaContainer = testContainerFactory.createKafka()
-    private val schemaRegistry: SchemaRegistryContainer = testContainerFactory.createSchemaRegistry(kafka)
-    private val config: Config = ConfigFactory.load()
-    private val topicConfig: Config = config.getConfig("kafka.producer.listen-topics")
-    private lateinit var producer: Producer<String, Message>
-
-    @get:Rule
-    val grpcCleanupRule: GrpcCleanupRule = GrpcCleanupRule()
-    private val listenBeginBlockStub =
-        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
-            grpcCleanupRule.register(
-                InProcessChannelBuilder.forName("listenBeginBlock").directExecutor().build()
-            )
-        )
-    private val listenEndBlockStub =
-        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
-            grpcCleanupRule.register(
-                InProcessChannelBuilder.forName("listenEndBlock").directExecutor().build()
-            )
-        )
-    private val listenDeliverTxStub =
-        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
-            grpcCleanupRule.register(
-                InProcessChannelBuilder.forName("listenDeliverTx").directExecutor().build()
-            )
-        )
-    private val listenCommitStub =
-        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
-            grpcCleanupRule.register(
-                InProcessChannelBuilder.forName("listenCommit").directExecutor().build()
-            )
-        )
+class AbciListenerServerWithoutSchemaRegistryTests : BaseTests() {
 
     @BeforeAll
     internal fun setUpAll() {
-        schemaRegistry.start()
-        producer = TestProtoProducer<String, Message>(schemaRegistry.baseUrl)
-            .createProducer(kafka.bootstrapServers)
+        kafka.start()
+        producer = TestProtoProducer<String, Message>(config)
+                .createProducer(kafka.bootstrapServers)
     }
 
     @AfterAll
     internal fun tearDownAll() {
         producer.close()
-        schemaRegistry.stop()
         kafka.stop()
     }
 
@@ -96,7 +52,7 @@ class ABCIListenerServerTest {
 
         grpcCleanupRule.register(
             InProcessServerBuilder.forName("listenBeginBlock").directExecutor()
-                .addService(ABCIListenerService(topicConfig, producer))
+                .addService(AbciListenerService(topicConfig, producer))
                 .build()
                 .start()
         )
@@ -141,23 +97,26 @@ class ABCIListenerServerTest {
         )
         assertThat(reply.javaClass).isEqualTo(ListenBeginBlockResponse::class.java)
 
-        val consumer = TestProtoConsumer<String, ListenBeginBlockRequest>(
+        val consumer = TestProtoConsumer<String, ByteArray>(
+            config = config,
             bootstrapServers = kafka.bootstrapServers,
-            schemaRegistryUrl = schemaRegistry.baseUrl,
             topic = topicConfig.getString(ListenTopic.BEGIN_BLOCK.topic),
-            valueClass = ListenBeginBlockRequest::class.java
         )
         consumer.consumeAndClose()
         assertThat(consumer.messages.size).isEqualTo(1)
-        assertThat(consumer.messages[0].value().req.header.height).isEqualTo(1)
-        assertThat(consumer.messages[0].value().res.eventsList[0].type).isEqualTo("testEventType1")
+        assertThat(consumer.messages[0].value() is ByteArray)
+        val result = assertDoesNotThrow("ListenBeginBlockRequest.parseFrom() should not throw an exception") {
+            ListenBeginBlockRequest.parseFrom(consumer.messages[0].value())
+        }
+        assertThat(result.req.header.height).isEqualTo(1)
+        assertThat(result.res.eventsList[0].type).isEqualTo("testEventType1")
     }
 
     @Test
     fun listenEndBlock(): Unit = runBlocking {
         grpcCleanupRule.register(
             InProcessServerBuilder.forName("listenEndBlock").directExecutor()
-                .addService(ABCIListenerService(topicConfig, producer))
+                .addService(AbciListenerService(topicConfig, producer))
                 .build()
                 .start()
         )
@@ -170,23 +129,26 @@ class ABCIListenerServerTest {
         )
         assertThat(reply.javaClass).isEqualTo(ListenEndBlockResponse::class.java)
 
-        val consumer = TestProtoConsumer<String, ListenEndBlockRequest>(
+        val consumer = TestProtoConsumer<String, ByteArray>(
+            config = config,
             bootstrapServers = kafka.bootstrapServers,
-            schemaRegistryUrl = schemaRegistry.baseUrl,
             topic = topicConfig.getString(ListenTopic.END_BLOCK.topic),
-            valueClass = ListenEndBlockRequest::class.java
         )
         consumer.consumeAndClose()
         assertThat(consumer.messages.size).isEqualTo(1)
-        assertThat(consumer.messages[0].value().req.height).isEqualTo(1)
-        assertThat(consumer.messages[0].value().res.eventsList.size).isEqualTo(0)
+        assertThat(consumer.messages[0].value() is ByteArray)
+        val result = assertDoesNotThrow("ListenBeginBlockRequest.parseFrom() should not throw an exception") {
+            ListenEndBlockRequest.parseFrom(consumer.messages[0].value())
+        }
+        assertThat(result.req.height).isEqualTo(1)
+        assertThat(result.res.eventsList.size).isEqualTo(0)
     }
 
     @Test
     fun listenDeliverTx(): Unit = runBlocking {
         grpcCleanupRule.register(
             InProcessServerBuilder.forName("listenDeliverTx").directExecutor()
-                .addService(ABCIListenerService(topicConfig, producer))
+                .addService(AbciListenerService(topicConfig, producer))
                 .build()
                 .start()
         )
@@ -200,24 +162,26 @@ class ABCIListenerServerTest {
         )
         assertThat(reply.javaClass).isEqualTo(ListenDeliverTxResponse::class.java)
 
-        val consumer = TestProtoConsumer<String, ListenDeliverTxRequest>(
+        val consumer = TestProtoConsumer<String, ByteArray>(
+            config = config,
             bootstrapServers = kafka.bootstrapServers,
-            schemaRegistryUrl = schemaRegistry.baseUrl,
             topic = topicConfig.getString(ListenTopic.DELIVER_TX.topic),
-            valueClass = ListenDeliverTxRequest::class.java
         )
         consumer.consumeAndClose()
         assertThat(consumer.messages.size).isEqualTo(1)
-        assertThat(consumer.messages[0].value().blockHeight).isEqualTo(1)
-        assertThat(consumer.messages[0].value().req.tx.toStringUtf8()).isEqualTo("testTx1")
-        assertThat(consumer.messages[0].value().res.code).isEqualTo(1)
+        assertThat(consumer.messages[0].value() is ByteArray)
+        val result = assertDoesNotThrow("ListenDeliverTxRequest.parseFrom() should not throw an exception") {
+            ListenDeliverTxRequest.parseFrom(consumer.messages[0].value())
+        }
+        assertThat(result.req.tx.toStringUtf8()).isEqualTo("testTx1")
+        assertThat(result.res.code).isEqualTo(1)
     }
 
     @Test
     fun listenCommit(): Unit = runBlocking {
         grpcCleanupRule.register(
             InProcessServerBuilder.forName("listenCommit").directExecutor()
-                .addService(ABCIListenerService(topicConfig, producer))
+                .addService(AbciListenerService(topicConfig, producer))
                 .build()
                 .start()
         )
@@ -247,16 +211,19 @@ class ABCIListenerServerTest {
         )
         assertThat(reply.javaClass).isEqualTo(ListenCommitResponse::class.java)
 
-        val consumer = TestProtoConsumer<String, ListenCommitRequest>(
+        val consumer = TestProtoConsumer<String, ByteArray>(
+            config = config,
             bootstrapServers = kafka.bootstrapServers,
-            schemaRegistryUrl = schemaRegistry.baseUrl,
             topic = topicConfig.getString(ListenTopic.COMMIT.topic),
-            valueClass = ListenCommitRequest::class.java
         )
         consumer.consumeAndClose()
         assertThat(consumer.messages.size).isEqualTo(1)
-        assertThat(consumer.messages[0].value().blockHeight).isEqualTo(1)
-        assertThat(consumer.messages[0].value().res.data.toStringUtf8()).isEqualTo("data123")
-        assertThat(consumer.messages[0].value().changeSetList[0].storeKey).isEqualTo("mockStore1")
+        assertThat(consumer.messages[0].value() is ByteArray)
+        val result = assertDoesNotThrow("ListenCommitRequest.parseFrom() should not throw an exception") {
+            ListenCommitRequest.parseFrom(consumer.messages[0].value())
+        }
+        assertThat(result.blockHeight).isEqualTo(1)
+        assertThat(result.res.data.toStringUtf8()).isEqualTo("data123")
+        assertThat(result.changeSetList[0].storeKey).isEqualTo("mockStore1")
     }
 }

--- a/src/test/kotlin/io/provenance/abci/listener/AbciListenerServerWithoutSchemaRegistryTests.kt
+++ b/src/test/kotlin/io/provenance/abci/listener/AbciListenerServerWithoutSchemaRegistryTests.kt
@@ -15,8 +15,11 @@ import cosmos.streaming.abci.v1.Grpc.ListenEndBlockResponse
 import io.grpc.inprocess.InProcessServerBuilder
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertDoesNotThrow
 import tendermint.abci.Types
 import tendermint.abci.Types.RequestBeginBlock
 import tendermint.abci.Types.RequestDeliverTx
@@ -26,9 +29,6 @@ import tendermint.abci.Types.ResponseCommit
 import tendermint.abci.Types.ResponseDeliverTx
 import tendermint.abci.Types.ResponseEndBlock
 import java.time.Instant
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.assertDoesNotThrow
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AbciListenerServerWithoutSchemaRegistryTests : BaseTests() {
@@ -37,7 +37,7 @@ class AbciListenerServerWithoutSchemaRegistryTests : BaseTests() {
     internal fun setUpAll() {
         kafka.start()
         producer = TestProtoProducer<String, Message>(config)
-                .createProducer(kafka.bootstrapServers)
+            .createProducer(kafka.bootstrapServers)
     }
 
     @AfterAll
@@ -100,7 +100,7 @@ class AbciListenerServerWithoutSchemaRegistryTests : BaseTests() {
         val consumer = TestProtoConsumer<String, ByteArray>(
             config = config,
             bootstrapServers = kafka.bootstrapServers,
-            topic = topicConfig.getString(ListenTopic.BEGIN_BLOCK.topic),
+            topic = topicConfig.getString(ListenTopic.BEGIN_BLOCK.topic)
         )
         consumer.consumeAndClose()
         assertThat(consumer.messages.size).isEqualTo(1)
@@ -132,7 +132,7 @@ class AbciListenerServerWithoutSchemaRegistryTests : BaseTests() {
         val consumer = TestProtoConsumer<String, ByteArray>(
             config = config,
             bootstrapServers = kafka.bootstrapServers,
-            topic = topicConfig.getString(ListenTopic.END_BLOCK.topic),
+            topic = topicConfig.getString(ListenTopic.END_BLOCK.topic)
         )
         consumer.consumeAndClose()
         assertThat(consumer.messages.size).isEqualTo(1)
@@ -165,7 +165,7 @@ class AbciListenerServerWithoutSchemaRegistryTests : BaseTests() {
         val consumer = TestProtoConsumer<String, ByteArray>(
             config = config,
             bootstrapServers = kafka.bootstrapServers,
-            topic = topicConfig.getString(ListenTopic.DELIVER_TX.topic),
+            topic = topicConfig.getString(ListenTopic.DELIVER_TX.topic)
         )
         consumer.consumeAndClose()
         assertThat(consumer.messages.size).isEqualTo(1)
@@ -214,7 +214,7 @@ class AbciListenerServerWithoutSchemaRegistryTests : BaseTests() {
         val consumer = TestProtoConsumer<String, ByteArray>(
             config = config,
             bootstrapServers = kafka.bootstrapServers,
-            topic = topicConfig.getString(ListenTopic.COMMIT.topic),
+            topic = topicConfig.getString(ListenTopic.COMMIT.topic)
         )
         consumer.consumeAndClose()
         assertThat(consumer.messages.size).isEqualTo(1)

--- a/src/test/kotlin/io/provenance/abci/listener/BaseTests.kt
+++ b/src/test/kotlin/io/provenance/abci/listener/BaseTests.kt
@@ -1,0 +1,53 @@
+package io.provenance.abci.listener
+
+import com.google.protobuf.Message
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import cosmos.streaming.abci.v1.ABCIListenerServiceGrpcKt
+import io.grpc.inprocess.InProcessChannelBuilder
+import io.grpc.testing.GrpcCleanupRule
+import net.christophschubert.cp.testcontainers.CPTestContainerFactory
+import net.christophschubert.cp.testcontainers.SchemaRegistryContainer
+import org.apache.kafka.clients.producer.Producer
+import org.junit.Rule
+import org.testcontainers.containers.KafkaContainer
+
+open class BaseTests {
+
+    protected val testContainerFactory: CPTestContainerFactory = CPTestContainerFactory()
+    protected val kafka: KafkaContainer = testContainerFactory.createKafka()
+    protected lateinit var schemaRegistry: SchemaRegistryContainer
+
+    protected val config: Config = ConfigFactory.load("test.conf")
+    protected val topicConfig: Config = config.getConfig("kafka.producer.listen-topics")
+
+    protected lateinit var producer: Producer<String, Message>
+
+    @get:Rule
+    val grpcCleanupRule: GrpcCleanupRule = GrpcCleanupRule()
+    protected val listenBeginBlockStub =
+        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
+            grpcCleanupRule.register(
+                InProcessChannelBuilder.forName("listenBeginBlock").directExecutor().build()
+            )
+        )
+    protected val listenEndBlockStub =
+        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
+            grpcCleanupRule.register(
+                InProcessChannelBuilder.forName("listenEndBlock").directExecutor().build()
+            )
+        )
+    protected val listenDeliverTxStub =
+        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
+            grpcCleanupRule.register(
+                InProcessChannelBuilder.forName("listenDeliverTx").directExecutor().build()
+            )
+        )
+    protected val listenCommitStub =
+        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
+            grpcCleanupRule.register(
+                InProcessChannelBuilder.forName("listenCommit").directExecutor().build()
+            )
+        )
+
+}

--- a/src/test/kotlin/io/provenance/abci/listener/BaseTests.kt
+++ b/src/test/kotlin/io/provenance/abci/listener/BaseTests.kt
@@ -3,8 +3,6 @@ package io.provenance.abci.listener
 import com.google.protobuf.Message
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import cosmos.streaming.abci.v1.ABCIListenerServiceGrpcKt
-import io.grpc.inprocess.InProcessChannelBuilder
 import io.grpc.testing.GrpcCleanupRule
 import net.christophschubert.cp.testcontainers.CPTestContainerFactory
 import net.christophschubert.cp.testcontainers.SchemaRegistryContainer

--- a/src/test/kotlin/io/provenance/abci/listener/BaseTests.kt
+++ b/src/test/kotlin/io/provenance/abci/listener/BaseTests.kt
@@ -25,28 +25,4 @@ open class BaseTests {
 
     @get:Rule
     val grpcCleanupRule: GrpcCleanupRule = GrpcCleanupRule()
-    protected val listenBeginBlockStub =
-        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
-            grpcCleanupRule.register(
-                InProcessChannelBuilder.forName("listenBeginBlock").directExecutor().build()
-            )
-        )
-    protected val listenEndBlockStub =
-        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
-            grpcCleanupRule.register(
-                InProcessChannelBuilder.forName("listenEndBlock").directExecutor().build()
-            )
-        )
-    protected val listenDeliverTxStub =
-        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
-            grpcCleanupRule.register(
-                InProcessChannelBuilder.forName("listenDeliverTx").directExecutor().build()
-            )
-        )
-    protected val listenCommitStub =
-        ABCIListenerServiceGrpcKt.ABCIListenerServiceCoroutineStub(
-            grpcCleanupRule.register(
-                InProcessChannelBuilder.forName("listenCommit").directExecutor().build()
-            )
-        )
 }

--- a/src/test/kotlin/io/provenance/abci/listener/BaseTests.kt
+++ b/src/test/kotlin/io/provenance/abci/listener/BaseTests.kt
@@ -49,5 +49,4 @@ open class BaseTests {
                 InProcessChannelBuilder.forName("listenCommit").directExecutor().build()
             )
         )
-
 }

--- a/src/test/kotlin/io/provenance/abci/listener/ByteArrayConsumer.kt
+++ b/src/test/kotlin/io/provenance/abci/listener/ByteArrayConsumer.kt
@@ -1,0 +1,15 @@
+package io.provenance.abci.listener
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import java.time.Duration
+import java.util.*
+import mu.KotlinLogging
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
+
+private val logger = KotlinLogging.logger {}
+

--- a/src/test/kotlin/io/provenance/abci/listener/ByteArrayConsumer.kt
+++ b/src/test/kotlin/io/provenance/abci/listener/ByteArrayConsumer.kt
@@ -1,15 +1,6 @@
 package io.provenance.abci.listener
 
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
-import java.time.Duration
-import java.util.*
 import mu.KotlinLogging
-import org.apache.kafka.clients.consumer.Consumer
-import org.apache.kafka.clients.consumer.ConsumerConfig
-import org.apache.kafka.clients.consumer.ConsumerRecord
-import org.apache.kafka.clients.consumer.KafkaConsumer
-import org.apache.kafka.common.serialization.ByteArrayDeserializer
+import java.util.*
 
 private val logger = KotlinLogging.logger {}
-

--- a/src/test/kotlin/io/provenance/abci/listener/TestProtoConsumer.kt
+++ b/src/test/kotlin/io/provenance/abci/listener/TestProtoConsumer.kt
@@ -8,12 +8,12 @@ import mu.KotlinLogging
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
+import org.apache.kafka.common.serialization.StringDeserializer
 import java.time.Duration
 import java.util.Collections
 import java.util.Properties
 import java.util.Random
-import org.apache.kafka.common.serialization.ByteArrayDeserializer
-import org.apache.kafka.common.serialization.StringDeserializer
 
 private val logger = KotlinLogging.logger {}
 

--- a/src/test/kotlin/io/provenance/abci/listener/TestProtoConsumer.kt
+++ b/src/test/kotlin/io/provenance/abci/listener/TestProtoConsumer.kt
@@ -1,9 +1,8 @@
 package io.provenance.abci.listener
 
-import com.google.protobuf.Message
 import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializerConfig
 import mu.KotlinLogging
 import org.apache.kafka.clients.consumer.ConsumerConfig
@@ -13,6 +12,8 @@ import java.time.Duration
 import java.util.Collections
 import java.util.Properties
 import java.util.Random
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
+import org.apache.kafka.common.serialization.StringDeserializer
 
 private val logger = KotlinLogging.logger {}
 
@@ -27,14 +28,14 @@ private val logger = KotlinLogging.logger {}
  * @property valueClass the specific Protobuf value type.
  * @constructor Creates a ProtoConsumer object.
  */
-class TestProtoConsumer<K, V : Message>(
+class TestProtoConsumer<K, V>(
+    private val config: Config,
     private val bootstrapServers: String,
-    private val schemaRegistryUrl: String,
+    private val schemaRegistryUrl: String? = null,
     private val topic: String,
-    private val valueClass: Class<V>
+    private val valueClass: Class<V>? = null
 ) : TestConsumer {
 
-    private val config: Config = ConfigFactory.load()
     private val consumer: KafkaConsumer<K, V> = KafkaConsumer(createConsumerProperties(bootstrapServers))
     val messages: MutableList<ConsumerRecord<K, V>> = mutableListOf()
 
@@ -50,14 +51,20 @@ class TestProtoConsumer<K, V : Message>(
         val props: Properties = config.getConfig("kafka.consumer.kafka-clients").toProperties()
         props[ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers!!
         props[ConsumerConfig.GROUP_ID_CONFIG] = "testgroup" + Random().nextInt()
-        props[AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG] = schemaRegistryUrl
+        props[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+        props[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = ByteArrayDeserializer::class.java
 
-        // Specifying the value parameter `V` type is not enough. We need to specify a
-        // specific protobuf value deserializer to be able to deserializer to a specific type.
-        // This is because the Cosmos Protobuf files do not include: `java_outer_classname`
-        // and `java_multiple_files = true` properties.
-        // https://docs.confluent.io/platform/current/schema-registry/serdes-develop/serdes-protobuf.html#protobuf-deserializer
-        props[KafkaProtobufDeserializerConfig.SPECIFIC_PROTOBUF_VALUE_TYPE] = valueClass
+        // When using the schema registry, use the KafkaProtobufDeserializer
+        if (!schemaRegistryUrl.isNullOrEmpty()) {
+            props[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = KafkaProtobufDeserializer::class.java
+            props[AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG] = schemaRegistryUrl
+            // Specifying the value parameter `V` type is not enough. We need to specify a
+            // specific protobuf value deserializer to be able to deserializer to a specific type.
+            // This is because the Cosmos Protobuf files do not include: `java_outer_classname`
+            // and `java_multiple_files = true` properties.
+            // https://docs.confluent.io/platform/current/schema-registry/serdes-develop/serdes-protobuf.html#protobuf-deserializer
+            props[KafkaProtobufDeserializerConfig.SPECIFIC_PROTOBUF_VALUE_TYPE] = valueClass
+        }
 
         return props
     }

--- a/src/test/kotlin/io/provenance/abci/listener/TestProtoProducer.kt
+++ b/src/test/kotlin/io/provenance/abci/listener/TestProtoProducer.kt
@@ -2,13 +2,12 @@ package io.provenance.abci.listener
 
 import com.google.protobuf.Message
 import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.Producer
 import org.apache.kafka.clients.producer.ProducerConfig
-import java.util.Properties
 import org.apache.kafka.common.serialization.StringSerializer
+import java.util.Properties
 
 /**
  * Produce Protobuf messages to Kafka.
@@ -35,8 +34,9 @@ class TestProtoProducer<K, V : Message>(
         props[ProducerConfig.INTERCEPTOR_CLASSES_CONFIG] = LoggingProducerInterceptor::class.qualifiedName
 
         // settings this property will tell the ProtobufSerializer ^^^ which serializer to use.
-        if (!schemaRegistryUrl.isNullOrEmpty())
+        if (!schemaRegistryUrl.isNullOrEmpty()) {
             props[AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG] = schemaRegistryUrl
+        }
 
         return props
     }

--- a/src/test/resources/test.conf
+++ b/src/test/resources/test.conf
@@ -47,9 +47,6 @@ kafka {
       enable.auto.commit = true
       auto.commit.interval.ms = 1000
       auto.offset.reset = earliest
-//      session.timout.ms = 30000
-      key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
-      value.deserializer=io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer
     }
   }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR makes a few improvements:
- Add a custom Protobuf Serializer that checks for the presence of a `schema.registry.url` property to determine which serializer to use.
  - when set, Protobuf schemas will be registered with the Confluent Schema Registry.
  - when not set, Protobuf message will be serialized to byte[]
- only distribute a tar.gz distribution to minimize the number of assets.
- updated deploy script.
- update release workflow
- updated unit tests

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/provenance-abci-listener/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
